### PR TITLE
Fix underscore conversion in monospaced text

### DIFF
--- a/j2m.go
+++ b/j2m.go
@@ -38,11 +38,11 @@ func JiraToMD(str string) string {
 			},
 		},
 		{ // Bold
-			re:   regexp.MustCompile(`\*(\S.*)\*`),
+			re:   regexp.MustCompile(`\*(\S[^*]*)\*`),
 			repl: "**$1**",
 		},
 		{ // Italic
-			re:   regexp.MustCompile(`\_(\S.*)\_`),
+			re:   regexp.MustCompile(`\b\_(\S[^_]*)\_`),
 			repl: "*$1*",
 		},
 		{ // Monospaced text


### PR DESCRIPTION
`foo_bar_baz` is being incorrectly converted to `foo*bar*baz` due to the italic regex